### PR TITLE
Use current date and generate random keys

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -40,4 +40,9 @@ attr_reader :characters
     decryption[:date] = date
     decryption
   end
+
+  def current_date
+    now = Time.now
+    now.strftime("%m%d%y")
+  end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -22,7 +22,7 @@ attr_reader :characters
     encryption.join
   end
 
-  def encrypt(message, key, date = current_date)
+  def encrypt(message, key = generate_key, date = current_date)
     shifts = Shift.new(key, date).total_shifts.values
     encryption = {}
     encryption[:encryption] = shift_message(message, shifts)
@@ -57,5 +57,4 @@ attr_reader :characters
     end
     key_number
   end
-
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -45,4 +45,8 @@ attr_reader :characters
     now = Time.now
     now.strftime("%m%d%y")
   end
+
+  def generate_number
+    rand(100000)
+  end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -47,6 +47,15 @@ attr_reader :characters
   end
 
   def generate_number
-    rand(100000)
+    rand(100000).to_i
   end
+
+  def generate_key
+    key_number = generate_number.to_s
+    until key_number.length == 5
+      key_number.prepend("0")
+    end
+    key_number
+  end
+
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -22,7 +22,7 @@ attr_reader :characters
     encryption.join
   end
 
-  def encrypt(message, key, date)
+  def encrypt(message, key, date = current_date)
     shifts = Shift.new(key, date).total_shifts.values
     encryption = {}
     encryption[:encryption] = shift_message(message, shifts)
@@ -31,7 +31,7 @@ attr_reader :characters
     encryption
   end
 
-  def decrypt(message, key, date)
+  def decrypt(message, key, date = current_date)
     shifts = Shift.new(key, date).total_shifts.values
     unshifts = shifts.map{|shift_value| shift_value * -1}
     decryption = {}

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -45,6 +45,16 @@ class EnigmaTest < Minitest::Test
   assert_equal expected, @enigma.encrypt("hello world", "02715")
   end
 
+  def test_it_can_encrypt_with_random_key_and_current_date
+    Time.stubs(:now).returns(Time.new(1995, 04, 8))
+    @enigma.stubs(:generate_number).returns(2715)
+    expected = {
+                encryption: "keder ohulw",
+                key: "02715",
+                date: "040895"
+                }
+  assert_equal expected, @enigma.encrypt("hello world")
+  end
 
   def test_it_can_decrypt_with_given_date_and_key
     expected = {
@@ -83,6 +93,4 @@ class EnigmaTest < Minitest::Test
     @enigma.stubs(:generate_number).returns(6)
     assert_equal "00006", @enigma.generate_key
   end
-
-
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -35,7 +35,7 @@ class EnigmaTest < Minitest::Test
   assert_equal expected, @enigma.encrypt("hello world", "02715", "040895")
   end
 
-  def test_it_can_encrypt_with_given_key_and_no_date
+  def test_it_can_encrypt_with_given_key_and_current_date
     Time.stubs(:now).returns(Time.new(1995, 04, 8))
     expected = {
                 encryption: "keder ohulw",
@@ -44,6 +44,7 @@ class EnigmaTest < Minitest::Test
                 }
   assert_equal expected, @enigma.encrypt("hello world", "02715")
   end
+
 
   def test_it_can_decrypt_with_given_date_and_key
     expected = {
@@ -54,7 +55,7 @@ class EnigmaTest < Minitest::Test
     assert_equal expected, @enigma.decrypt("keder ohulw", "02715", "040895")
   end
 
-  def test_it_can_decrypt_with_given_key_and_no_date
+  def test_it_can_decrypt_with_given_key_and_current_date
     Time.stubs(:now).returns(Time.new(1995, 04, 8))
     expected = {
                 decryption: "hello world",
@@ -72,6 +73,15 @@ class EnigmaTest < Minitest::Test
   def test_it_can_get_random_number
     number = @enigma.generate_number
     assert_instance_of Integer, number
+  end
+
+  def test_it_can_generate_keys
+    @enigma.stubs(:generate_number).returns(23456)
+    assert_equal "23456", @enigma.generate_key
+    @enigma.stubs(:generate_number).returns(3456)
+    assert_equal "03456", @enigma.generate_key
+    @enigma.stubs(:generate_number).returns(6)
+    assert_equal "00006", @enigma.generate_key
   end
 
 

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -43,4 +43,10 @@ class EnigmaTest < Minitest::Test
                 }
     assert_equal expected, @enigma.decrypt("keder ohulw", "02715", "040895")
   end
+
+  def test_it_can_get_current_date
+    Time.stubs(:now).returns(Time.new(2020, 04, 15))
+    assert_equal "041520", @enigma.current_date
+  end
+
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -26,7 +26,7 @@ class EnigmaTest < Minitest::Test
     assert_equal "keder ohulw.", @enigma.shift_message("Hello World.", [3, 27, 73, 20])
   end
 
-  def test_it_can_encrypt
+  def test_it_can_encrypt_with_given_date_and_key
     expected = {
                 encryption: "keder ohulw",
                 key: "02715",
@@ -35,7 +35,16 @@ class EnigmaTest < Minitest::Test
   assert_equal expected, @enigma.encrypt("hello world", "02715", "040895")
   end
 
-  def test_it_can_decrypt
+  # def test_it_can_encrypt_with_given_date_and_key
+  #   expected = {
+  #               encryption: "keder ohulw",
+  #               key: "02715",
+  #               date: "040895"
+  #               }
+  # assert_equal expected, @enigma.encrypt("hello world", "02715", "040895")
+  # end
+
+  def test_it_can_decrypt_with_given_date_and_key
     expected = {
                 decryption: "hello world",
                 key: "02715",

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -35,14 +35,15 @@ class EnigmaTest < Minitest::Test
   assert_equal expected, @enigma.encrypt("hello world", "02715", "040895")
   end
 
-  # def test_it_can_encrypt_with_given_date_and_key
-  #   expected = {
-  #               encryption: "keder ohulw",
-  #               key: "02715",
-  #               date: "040895"
-  #               }
-  # assert_equal expected, @enigma.encrypt("hello world", "02715", "040895")
-  # end
+  def test_it_can_encrypt_with_given_key_and_no_date
+    Time.stubs(:now).returns(Time.new(1995, 04, 8))
+    expected = {
+                encryption: "keder ohulw",
+                key: "02715",
+                date: "040895"
+                }
+  assert_equal expected, @enigma.encrypt("hello world", "02715")
+  end
 
   def test_it_can_decrypt_with_given_date_and_key
     expected = {
@@ -51,6 +52,16 @@ class EnigmaTest < Minitest::Test
                 date: "040895"
                 }
     assert_equal expected, @enigma.decrypt("keder ohulw", "02715", "040895")
+  end
+
+  def test_it_can_decrypt_with_given_key_and_no_date
+    Time.stubs(:now).returns(Time.new(1995, 04, 8))
+    expected = {
+                decryption: "hello world",
+                key: "02715",
+                date: "040895"
+                }
+    assert_equal expected, @enigma.decrypt("keder ohulw", "02715")
   end
 
   def test_it_can_get_current_date

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -69,4 +69,10 @@ class EnigmaTest < Minitest::Test
     assert_equal "041520", @enigma.current_date
   end
 
+  def test_it_can_get_random_number
+    number = @enigma.generate_number
+    assert_instance_of Integer, number
+  end
+
+
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -4,6 +4,7 @@ class ShiftTest < Minitest::Test
   def setup
     @shift = Shift.new("02715", "040895")
     @shift2 = Shift.new("12134", "121205")
+    @shift3 = Shift.new("09715", "040895")
   end
 
   def test_it_exists
@@ -35,6 +36,8 @@ class ShiftTest < Minitest::Test
   def test_it_can_get_keys_collection
     expected = {A: 2, B: 27, C: 71, D: 15}
     assert_equal expected, @shift.keys_collection
+    expected = {A: 9, B: 97, C: 71, D: 15}
+    assert_equal expected, @shift3.keys_collection
   end
 
   def test_it_can_get_total_shifts


### PR DESCRIPTION
Adds functionality to get today's date and put it into the mmddyy format that is needed for the encryption algorithm to work  properly. Adds functionality to generate random 5 digit keys. Adds default values to the encrypt  method such that in the absence of a key or date argument, the encrypt method will generate a random key, and use today's date. Adds default values to the decrypt method such that in the absence of a date argument, it will use today's date.